### PR TITLE
POC for chrome style callbacks

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,10 +20,11 @@
   "author": "Stuart Knightley",
   "license": "BSD",
   "dependencies": {
-    "esprima": "~1.0.2",
     "escodegen": "~0.0.15",
+    "escope": "~0.0.13",
+    "esprima": "~1.0.2",
     "estraverse": "~0.0.4",
-    "escope": "~0.0.13"
+    "lodash": "^4.17.4"
   },
   "devDependencies": {
     "jasmine-node": "1.0.x",


### PR DESCRIPTION
Doesn't properly work with catches, but at least converts the main part of it.

For the following callback style:

```javascript
    getDetails(function(hm5) {
      getLongLat(function (hm6) {
        getNearbyBars(function (hm4) {
          return console.log({foo: 'bar'});
        }, function (hm) {
          return console.log();
        });
      }, function (hm2) {
        return console.log();
      });
    }, function(hm3) {
      return console.log();
    });
```